### PR TITLE
fix card title on intro page

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -22,7 +22,7 @@ export const HighlightedWorkshops = () => (
           <a className="pagination-nav__link card padding--lg cardContainer" 
           href="./getting-started/aks-automatic">
             <h2 className="text--truncate cardTitle">
-            Getting Started with AKS Automatic
+            Kubernetes the Easy Way with AKS Automatic
             </h2>
             <p className="cardDescription">
               Learn how to deploy a Kubernetes cluster using AKS Automatic. </p>


### PR DESCRIPTION
## Purpose
Fixed the card title on the intro page to match the new title of the Kubernetes the Easy Way with AKS Automatic lab
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
npm run start
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Navigate to the intro page. Confirm the card title matches the Kubernetes the Easy Way lab title
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->