### PR TITLE
Update ACR extension

### DIFF
--- a/docs/security/acr-patching.md
+++ b/docs/security/acr-patching.md
@@ -307,7 +307,7 @@ Before we enable continuous patching, let's inspect the imported image to see wh
 1. Install the Preview ACR Extension for ACR Continuous Patching. When prompted for confirmation, confirm the installation by typing in `y` and pressing Enter.
 
     ```bash
-    az extension add --source https://acrcssc.z5.web.core.windows.net/acrcssc-1.1.1rc11-py3-none-any.whl
+az extension add --source https://acrcssc.z5.web.core.windows.net/debug/acrcssc-1.0.0b2-py3-none-any.whl
     ```
 
 2. Create the ACR Continuous Patching configuration file:

--- a/docs/security/acr-patching.md
+++ b/docs/security/acr-patching.md
@@ -307,7 +307,7 @@ Before we enable continuous patching, let's inspect the imported image to see wh
 1. Install the Preview ACR Extension for ACR Continuous Patching. When prompted for confirmation, confirm the installation by typing in `y` and pressing Enter.
 
     ```bash
-    az extension add --source https://acrcssc.z5.web.core.windows.net/acrcssc-1.1.1rc7-py3-none-any.whl
+    az extension add --source https://acrcssc.z5.web.core.windows.net/acrcssc-1.1.1rc11-py3-none-any.whl
     ```
 
 2. Create the ACR Continuous Patching configuration file:

--- a/docs/security/acr-patching.md
+++ b/docs/security/acr-patching.md
@@ -307,7 +307,7 @@ Before we enable continuous patching, let's inspect the imported image to see wh
 1. Install the Preview ACR Extension for ACR Continuous Patching. When prompted for confirmation, confirm the installation by typing in `y` and pressing Enter.
 
     ```bash
-az extension add --source https://acrcssc.z5.web.core.windows.net/debug/acrcssc-1.0.0b2-py3-none-any.whl
+az extension add -n acrcssc
     ```
 
 2. Create the ACR Continuous Patching configuration file:


### PR DESCRIPTION
This pull request updates the documentation for enabling ACR Continuous Patching by modifying the command to install the Preview ACR Extension. The change ensures that the documentation reflects the latest version of the extension.

* [`docs/security/acr-patching.md`](diffhunk://#diff-bf44030ea47110f8316fec9e0c32c26e159116b7f6a0e0beb8305f23b8abc96aL310-R310): Updated the ACR extension installation command to use version `1.1.1rc11` instead of `1.1.1rc7`.