### PR TITLE
fix(platform-engineering): Env Var naming for interpolation for CAPZ …

### DIFF
--- a/docs/platform-engineering/aks-capz-aso.md
+++ b/docs/platform-engineering/aks-capz-aso.md
@@ -182,7 +182,7 @@ In this step, we will do the following:
   az role assignment create \
     --assignee "${PRINCIPAL_ID}" \
     --role "Managed Identity Operator" \
-    --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${IDENTITY_RG}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${IDENTITY_NAME}"
+    --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MANAGED_IDENTITY_NAME}"
   ```
 
 4. Creating federated identity credential: **aks-labs-capz-manager-credential**


### PR DESCRIPTION
…User MSI

fixing and keeping the environment variables used for role based access permissions on the CAPZ User MSI.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

To ensure the documentation when assigning the User MSI for CAPZ the correct role types, we are using the correct env vars for resource group and managed identity name.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Read the docs/Run the lab (docs/platform-engineering/aks-capz-aso)

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid

- Lab docs successfully deploy a cluster with the correct User MSI and RBAC roles.

## Other Information
<!-- Add any other helpful information that may be needed here. -->